### PR TITLE
Update URI open calls for Ruby 3

### DIFF
--- a/japi.gemspec
+++ b/japi.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'configurations', '~> 2.2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "yard"

--- a/lib/japi/trebek.rb
+++ b/lib/japi/trebek.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 module JAPI
   # Interface for creating and requesting Clues & Categories
   #
@@ -12,8 +14,7 @@ module JAPI
       # @return [Array<Clue>] A list of random clues
       def random(count = 1)
         url = base_url + "random/?" + URI.encode_www_form({count: count})
-        response = JSON.parse(open(url).read)
-
+        response = JSON.parse(URI.open(url).read)
         response.map do |clue|
           Clue.new(clue)
         end
@@ -39,7 +40,7 @@ module JAPI
           end
         end
         query = URI.encode_www_form(options)
-        response = JSON.parse(open(base_url + 'clues/?' + query).read)
+        response = JSON.parse(URI.open(base_url + 'clues/?' + query).read)
 
         response.map do |clue|
           Clue.new(clue)
@@ -63,7 +64,7 @@ module JAPI
           end
         end
         query = URI.encode_www_form(options)
-        response = JSON.parse(open(base_url + 'categories/?' + query).read)
+        response = JSON.parse(URI.open(base_url + 'categories/?' + query).read)
 
         response.map do |category|
           Category.new(category)
@@ -77,7 +78,7 @@ module JAPI
       # @return [Category] A list of clues that fit the query params
       def category(id)
         query = URI.encode_www_form(id: id)
-        response = JSON.parse(open(base_url + 'category/?' + query).read)
+        response = JSON.parse(URI.open(base_url + 'category/?' + query).read)
         Category.new(response)
       end
 


### PR DESCRIPTION
I just came across this awesome project but I was unable to get it working due to, what looks like, an issue with Ruby 3 since this is just a bit stale. I am not a huge ruby dev however, so I am open to suggestions but this at least was able to solve my issues using this in a basic sinatra app.

This is what led me to the change for reference: https://stackoverflow.com/questions/65937714/no-such-file-or-directory-rb-sysopen-for-external-url-rails-6-11-ruby-3


I also had Bundler2 so I changed that and figured I would throw that in as well